### PR TITLE
Struct support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,27 @@ iex(4)> ~m(^name)a = %{name: "Megan"}
 ** (MatchError) no match of right hand side value: %{name: "Megan"}
 ```
 
+If you need to match on structs, the first word should be '%' followed by the
+name of the module:
+
+```elixir
+iex(1)> import ShortMaps
+nil
+iex(2)> defmodule Foo do
+...(2)>  defstruct bar: nil
+...(2)>end
+{:module, Foo,
+ <<...>>,
+ [bar: nil]}
+
+iex(3)> ~m(%Foo bar) = %Foo{bar: 5}
+%Foo{bar: 5}
+iex(4)> bar
+5
+iex(5)> ~m(%Foo ^bar)a = %Foo{bar: 12}
+** (MatchError) no match of right hand side value: %Foo{bar: 12}
+```
+
 You can see more examples and read some docs in the docs for the `sigil_m`
 macro.
 

--- a/lib/short_maps.ex
+++ b/lib/short_maps.ex
@@ -7,10 +7,12 @@ defmodule ShortMaps do
   Returns a map with the given keys bound to variables with the same name.
 
   This macro sigil is used to reduce boilerplate when writing pattern matches on
-  maps that bind variables with the same name as the map keys. For example, this
-  is very common Elixir code:
+  maps that bind variables with the same name as the map keys. For example,
+  given a map that looks like this:
 
       my_map = %{foo: "foo", bar: "bar", baz: "baz"}
+
+  ..the following is very common Elixir code:
 
       %{foo: foo, bar: bar, baz: baz} = my_map
       foo #=> "foo"
@@ -35,6 +37,33 @@ defmodule ShortMaps do
 
       Test.test %{foo: "hello world"} #=> "hello world"
       Test.test %{bar: "hey there!"}  #=> :no_match
+
+  ## Pinning
+
+  Matching using the `~m` sigil has full support for the pin operator:
+
+      bar = "bar"
+      ~m(foo ^bar) = %{foo: "foo", bar: "bar"} #=> this is ok, `bar` matches
+      foo #=> "foo"
+      bar #=> "bar"
+      ~m(foo ^bar) = %{foo: "FOO", bar: "bar"} #=> this is still ok
+      foo #=> "FOO"; since we didn't pin it, it's now bound to a new value
+      bar #=> "bar"
+      ~m(foo ^bar) = %{foo: "foo", bar: "BAR"} #=> will raise MatchError
+
+  ## Structs
+
+  For using structs instead of plain maps, the first word must be prefixed with
+  '%':
+
+      defmodule Foo do
+        defstruct bar: nil
+      end
+
+      ~m(%Foo bar)a = %Foo{bar: 4711}
+      bar #=> 4711
+
+  _NOTE: Structs only support atom keys, so you must use the 'a' modifier._
 
   ## Modifiers
 

--- a/lib/short_maps.ex
+++ b/lib/short_maps.ex
@@ -77,10 +77,10 @@ defmodule ShortMaps do
 
   defp do_sigil_m(_line, ["%" <> _struct_name | _words], ?s),
     do: raise(ArgumentError, "structs can only consist of atom keys")
-  defp do_sigil_m(_line, ["%" <> struct_name | words], ?a) do
+  defp do_sigil_m(line, ["%" <> struct_name | words], ?a) do
     struct = String.to_atom("Elixir." <> struct_name)
     pairs = make_pairs(words, ?a)
-    quote do: struct(__MODULE__.unquote(struct), unquote(pairs))
+    quote do: %__MODULE__.unquote(struct){unquote_splicing(pairs)}
   end
 
   defp do_sigil_m(line, words, modifier) do

--- a/test/short_maps_test.exs
+++ b/test/short_maps_test.exs
@@ -81,10 +81,17 @@ defmodule ShortMapsTest do
     assert ~m(%Foo bar)a == %Foo{bar: 1}
   end
 
-  test "when using structs, ignores unrelated keys" do
-    bar = 1
-    baaz = 2
-    assert ~m(%Foo bar baaz)a == %Foo{bar: 1}
+  test "struct syntax can be used in regular matches" do
+    assert ~m(%Foo bar)a = %Foo{bar: "123"}
+    bar # this removes the "variable bar is unused" warning
+  end
+
+  test "when using structs, fails on non-existing keys" do
+    code = quote do: ~m(%Foo bar baaz)a = %Foo{bar: 1}
+    msg = ~r/unknown key :baaz for struct ShortMapsTest.Foo/
+    assert_raise CompileError, msg, fn ->
+      Code.eval_quoted(code, [], __ENV__)
+    end
   end
 
   test "when using structs, only accepts 'a' modifier" do

--- a/test/short_maps_test.exs
+++ b/test/short_maps_test.exs
@@ -50,6 +50,15 @@ defmodule ShortMapsTest do
     assert FunctionHead.test(%{baz: "bong"}) == :no_match
   end
 
+  defmodule Foo do
+    defstruct bar: nil
+  end
+
+  test "supports structs" do
+    bar = 1
+    assert ~m(Foo bar)a == %Foo{bar: 1}
+  end
+
   test "supports atom keys with the 'a' modifier" do
     assert ~m(foo bar)a = %{foo: "foo", bar: "bar"}
     assert {foo, bar} == {"foo", "bar"}

--- a/test/short_maps_test.exs
+++ b/test/short_maps_test.exs
@@ -50,15 +50,6 @@ defmodule ShortMapsTest do
     assert FunctionHead.test(%{baz: "bong"}) == :no_match
   end
 
-  defmodule Foo do
-    defstruct bar: nil
-  end
-
-  test "supports structs" do
-    bar = 1
-    assert ~m(Foo bar)a == %Foo{bar: 1}
-  end
-
   test "supports atom keys with the 'a' modifier" do
     assert ~m(foo bar)a = %{foo: "foo", bar: "bar"}
     assert {foo, bar} == {"foo", "bar"}
@@ -78,6 +69,30 @@ defmodule ShortMapsTest do
   test "no interpolation is supported" do
     code = quote do: ~m(foo #{bar} baz)a
     msg = "interpolation is not supported with the ~m sigil"
+    assert_raise ArgumentError, msg, fn -> Code.eval_quoted(code) end
+  end
+
+  defmodule Foo do
+    defstruct bar: nil
+  end
+
+  test "supports structs" do
+    bar = 1
+    assert ~m(%Foo bar)a == %Foo{bar: 1}
+  end
+
+  test "when using structs, ignores unrelated keys" do
+    bar = 1
+    baaz = 2
+    assert ~m(%Foo bar baaz)a == %Foo{bar: 1}
+  end
+
+  test "when using structs, only accepts 'a' modifier" do
+    code = quote do
+      bar = 5
+      ~m(%Foo bar)s
+    end
+    msg = "structs can only consist of atom keys"
     assert_raise ArgumentError, msg, fn -> Code.eval_quoted(code) end
   end
 end


### PR DESCRIPTION
Add support for matching structs as well; something that can be especially useful in function heads etc, where you often want to make sure the supplied parameter is of the correct type, as well as pick out fields from the struct.
