### PR TITLE
Prefix unused line argument to do_sigil_m/3 with '_' to avoid warning

### DIFF
--- a/lib/short_maps.ex
+++ b/lib/short_maps.ex
@@ -106,7 +106,7 @@ defmodule ShortMaps do
 
   defp do_sigil_m(_line, ["%" <> _struct_name | _words], ?s),
     do: raise(ArgumentError, "structs can only consist of atom keys")
-  defp do_sigil_m(line, ["%" <> struct_name | words], ?a) do
+  defp do_sigil_m(_line, ["%" <> struct_name | words], ?a) do
     struct = String.to_atom("Elixir." <> struct_name)
     pairs = make_pairs(words, ?a)
     quote do: %__MODULE__.unquote(struct){unquote_splicing(pairs)}


### PR DESCRIPTION
Sorry, seems I left this warning in there last time around..
