### PR TITLE
Remove unused module attribute

### DIFF
--- a/lib/short_maps.ex
+++ b/lib/short_maps.ex
@@ -1,8 +1,6 @@
 defmodule ShortMaps do
   @default_modifier ?s
 
-  @first_letter_uppercase ~r/^\p{Lu}/u
-
   @doc ~S"""
   Returns a map with the given keys bound to variables with the same name.
 


### PR DESCRIPTION
Removes a compile time warning:

`warning: module attribute @first_letter_uppercase was set but never used
  lib/short_maps.ex:4`